### PR TITLE
reduce dependencies, build both release and pre-release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,10 @@ RUN apt install -y -q \
     curl \
     gcc \
     git \
-    libdb5.3-dev \
-    libgmp-dev \
-    libjson-c-dev \
-    libxml2-dev \
     make \
     patchelf \
-    xz-utils
+    xz-utils \
+    libgmp-dev
 
 COPY build /root
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -3,7 +3,13 @@
 set -ex
 
 VERSION=$1
-URL=https://alpha.gnu.org/gnu/gnucobol/gnucobol-${VERSION}.tar.xz
+if [[ "${VERSION}" == "1.1" ]]; then
+   URL=https://ftp.gnu.org/gnu/gnucobol/gnu-cobol-${VERSION}.tar.gz
+elif [[ "${VERSION}" =~ "rc" ]] || [[ "${VERSION}" =~ "beta" ]]; then
+   URL=https://alpha.gnu.org/gnu/gnucobol/gnucobol-${VERSION}.tar.xz
+else
+   URL=https://ftp.gnu.org/gnu/gnucobol/gnucobol-${VERSION}.tar.xz
+fi
 
 FULLNAME=gnucobol-${VERSION}
 OUTPUT=$2/${FULLNAME}.tar.xz
@@ -27,7 +33,7 @@ mkdir -p ${BUILD_DIR}
 pushd ${BUILD_DIR}
 curl -sL ${URL} | tar Jxf - --strip-components=1
 # https://stackoverflow.com/questions/37060747/escaping-origin-for-libtool-based-project
-./configure LDFLAGS="-Wl,-rpath,'\$\$ORIGIN/../lib'" --without-curses --with-math=gmp --with-db --with-xml2 --with-json-json-c
+./configure LDFLAGS="-Wl,-rpath,'\$\$ORIGIN/../lib'" --with-math=gmp --without-db --without-curses --without-xml2 --without-json
 make -j$(nproc)
 make prefix=${STAGING_DIR} install
 


### PR DESCRIPTION
* variable URL allowing both the (preferable) final versions be built as well as stable "special" 1.1 as well as the preview releases, which were previously used here

* dropped all dependencies we don't need at compile-time; only downsides:
   * a compile error with GC 3.2+ on code using it, but we can change it via default command line options to be dropped `-Wno-unsupported`
   * URI checks in code will be lax (instead of libxml2's thorough check), but we want codegen, not the check of that literal...


Note: I highly suggest to try building versions 1.1, 2.2 and 3.2-rc2 after this was pulled.